### PR TITLE
Headless: stable Xvfb+noVNC stack, qml_runner, auto-build qml_ros2_plugin (Humble)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,39 @@
 .vscode/
 .idea/
 cmake-build-*/
-build/
 
 *.qmlc
+
+# build/install/log (colcon)
+build/
+install/
+log/
+
+# editor/OS
+.vscode/
+.idea/
+.DS_Store
+
+# temp & logs
+*.log
+/tmp/
+*.swp
+
+# our local backups
+*.bak
+
+# docker layer/stray files accidentally created
+/[0-9a-f]{8,}
+/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*
+GIT
+/Using
+
+# compiled stuff
+*.o
+*.so
+*.a
+
+# Python junk (just in case)
+__pycache__/
+*.pyc
+GIT

--- a/cmake/50.qml_ros2_plugin.qml.sh.in
+++ b/cmake/50.qml_ros2_plugin.qml.sh.in
@@ -1,0 +1,12 @@
+i# Export QML2_IMPORT_PATH for qml_ros2_plugin
+if [ -d "@CMAKE_INSTALL_PREFIX@/qml_ros2_plugin/lib" ]; then
+  if [ -z "${QML2_IMPORT_PATH:-}" ]; then
+    export QML2_IMPORT_PATH="@CMAKE_INSTALL_PREFIX@/qml_ros2_plugin/lib"
+  else
+    export QML2_IMPORT_PATH="@CMAKE_INSTALL_PREFIX@/qml_ros2_plugin/lib:${QML2_IMPORT_PATH}"
+  fi
+  if [ -d "@CMAKE_INSTALL_PREFIX@/qml_ros2_plugin/lib/Ros2" ] && [ ! -e "@CMAKE_INSTALL_PREFIX@/qml_ros2_plugin/lib/Ros" ]; then
+    ln -s "@CMAKE_INSTALL_PREFIX@/qml_ros2_plugin/lib/Ros2" "@CMAKE_INSTALL_PREFIX@/qml_ros2_plugin/lib/Ros" 2>/dev/null || true
+  fi
+fi
+

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -3,8 +3,22 @@ FROM ros:humble
 # 빌드 도구 + colcon + Qt5 QML 런처
 RUN apt-get update && apt-get install -y \
     build-essential cmake git python3-colcon-common-extensions \
-    qtdeclarative5-dev-tools qml-module-qtquick-controls \
+    # Qt5 dev + QML 런타임 모듈
+    qtbase5-dev qtdeclarative5-dev qtdeclarative5-dev-tools \
+    qml-module-qtquick-controls qml-module-qtquick-controls2 \
     qml-module-qtquick-layouts qml-module-qtgraphicaleffects \
+    # Qt5 Multimedia + GStreamer
+    qtmultimedia5-dev qml-module-qtmultimedia \
+    libqt5multimedia5 libqt5multimedia5-plugins \
+    gstreamer1.0-tools gstreamer1.0-libav \
+    gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+    # ROS deps (앞서 필요했던 것들)
+    ros-humble-image-transport \
+    ros-humble-cv-bridge \
+    ros-humble-tf2-ros \
+    ros-humble-ros-babel-fish \
+    ros-humble-ros-babel-fish-test-msgs \
+    ros-humble-example-interfaces \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /ws

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,28 +1,87 @@
-FROM ros:humble
+ FROM ros:humble
+ 
+ # Build tools, colcon, Qt5(QML), Multimedia, GStreamer, ROS deps
+ RUN apt-get update && apt-get install -y \
+     build-essential \
+     cmake \
+     git \
+     python3-colcon-common-extensions \
+     # Qt5 dev + QML 런타임/툴
+     qtbase5-dev \
+     qtbase5-dev-tools \
+     qtdeclarative5-dev \
+     qtdeclarative5-dev-tools \
+     qml-module-qtquick-controls \
+     qml-module-qtquick-controls2 \
+     qml-module-qtquick-layouts \
+     qml-module-qtgraphicaleffects \
+     # Multimedia + GStreamer
+     qtmultimedia5-dev \
+     qml-module-qtmultimedia \
+     libqt5multimedia5 \
+     libqt5multimedia5-plugins \
+     gstreamer1.0-tools \
+     gstreamer1.0-libav \
+     gstreamer1.0-plugins-base \
+     gstreamer1.0-plugins-good \
+     gstreamer1.0-plugins-bad \
+     # ROS deps
+     ros-humble-image-transport \
+     ros-humble-cv-bridge \
+     ros-humble-tf2-ros \
+     ros-humble-example-interfaces \
+     ros-humble-action-tutorials-interfaces \
+     ros-humble-ros-babel-fish \
+     ros-humble-ros-babel-fish-test-msgs \
+     # qtchooser
+     qtchooser \
+     qt5-qmake \
++    # headless GUI utils
++    wmctrl \
+     && rm -rf /var/lib/apt/lists/*
+ 
+ WORKDIR /ws
+ SHELL ["/bin/bash", "-lc"]
+ 
+ # ros_babel_fish 소스 포함(humble 브랜치) + (가능하면) test_msgs 바이너리
+ RUN mkdir -p /ws/src && cd /ws/src && \
+     git clone -b humble https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
+ RUN apt-get update && apt-get install -y ros-humble-ros-babel-fish-test-msgs || true && rm -rf /var/lib/apt/lists/*
+ 
+ # qtchooser 프로파일을 /usr/bin 기준으로 고정 (현재 컨테이너에서 qmlscene 위치가 /usr/bin/qmlscene)
+ RUN mkdir -p /etc/xdg/qtchooser && \
+     printf "/usr/bin\n/usr/lib/x86_64-linux-gnu\n" > /etc/xdg/qtchooser/qt5.conf
+ ENV QT_SELECT=qt5
+ 
+ # --- noVNC & VNC & X 가상디스플레이 & 유틸 ---
+ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+     xvfb x11vnc fluxbox \
+     novnc python3-websockify \
+     iproute2 curl \
+  && rm -rf /var/lib/apt/lists/*
+ 
+ # 선택: 편의를 위해 기본 Qt 선택값을 Qt5로
+ ENV QT_SELECT=qt5
+ 
+ # noVNC 기본 포트
+ EXPOSE 6080
+ 
+ # 컨테이너 로그인 시 ROS 환경 자동 로드
+ RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc
++
++# ----[추가] 런타임 스크립트/런처 복사 ----
++# 로컬 레포에 다음 파일들이 존재해야 함:
++#  - scripts/qml_env.sh
++#  - scripts/run-sub
++#  - scripts/run-pub
++#  - docker/run-headless.sh
++COPY scripts/qml_env.sh /usr/local/share/qml_ros2_plugin/qml_env.sh
++COPY scripts/run-sub /usr/local/bin/run-sub
++COPY scripts/run-pub /usr/local/bin/run-pub
++COPY docker/run-headless.sh /usr/local/bin/run-headless.sh
++RUN chmod +x /usr/local/bin/run-sub /usr/local/bin/run-pub /usr/local/bin/run-headless.sh \
++ && ln -sf /usr/local/share/qml_ros2_plugin/qml_env.sh /usr/local/bin/qml_env.sh || true
++
++# (선택) 컨테이너가 올라오면 바로 headless 스택 가동
++CMD ["/usr/local/bin/run-headless.sh"]
 
-# 빌드 도구 + colcon + Qt5 QML 런처
-RUN apt-get update && apt-get install -y \
-    build-essential cmake git python3-colcon-common-extensions \
-    # Qt5 dev + QML 런타임 모듈
-    qtbase5-dev qtdeclarative5-dev qtdeclarative5-dev-tools \
-    qml-module-qtquick-controls qml-module-qtquick-controls2 \
-    qml-module-qtquick-layouts qml-module-qtgraphicaleffects \
-    # Qt5 Multimedia + GStreamer
-    qtmultimedia5-dev qml-module-qtmultimedia \
-    libqt5multimedia5 libqt5multimedia5-plugins \
-    gstreamer1.0-tools gstreamer1.0-libav \
-    gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
-    # ROS deps (앞서 필요했던 것들)
-    ros-humble-image-transport \
-    ros-humble-cv-bridge \
-    ros-humble-tf2-ros \
-    ros-humble-ros-babel-fish \
-    ros-humble-ros-babel-fish-test-msgs \
-    ros-humble-example-interfaces \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /ws
-SHELL ["/bin/bash", "-lc"]
-
-# ROS 환경 자동 로드(컨테이너 로그인 시)
-RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc

--- a/docker/Dockerfile.humble-qt
+++ b/docker/Dockerfile.humble-qt
@@ -1,0 +1,63 @@
+FROM osrf/ros:humble-desktop
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV QT_SELECT=qt5
+
+# 필수 패키지
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    bash ca-certificates curl git locales sudo less nano \
+    build-essential cmake python3-pip python3-colcon-common-extensions \
+    xvfb x11vnc fluxbox novnc websockify wmctrl x11-apps \
+    libgl1-mesa-dri mesa-utils \
+    qtbase5-dev qtdeclarative5-dev \
+    qtmultimedia5-dev qml-module-qtmultimedia \
+    qml-module-qtquick2 qml-module-qtquick-controls qml-module-qtquick-controls2 \
+    qml-module-qtgraphicaleffects qml-module-qtquick-layouts \
+    qml-module-qt-labs-platform qml-module-qt-labs-settings \
+    qml-module-qt-labs-folderlistmodel \
+    libqt5x11extras5 libqt5x11extras5-dev libqt5svg5 libqt5svg5-dev \
+    qtchooser qt5-qmake qtdeclarative5-dev-tools \
+    ros-humble-ros-babel-fish ros-humble-ros-babel-fish-test-msgs ros-humble-example-interfaces \
+ && rm -rf /var/lib/apt/lists/*
+
+# qtchooser 프로파일
+RUN mkdir -p /etc/xdg/qtchooser && \
+    printf "/usr/bin\n/usr/lib/x86_64-linux-gnu\n" > /etc/xdg/qtchooser/qt5.conf
+
+WORKDIR /ws
+SHELL ["/bin/bash","-lc"]
+
+# 헤드리스 기본 환경
+ENV DISPLAY=:0 \
+    QT_QPA_PLATFORM=xcb \
+    QT_QUICK_BACKEND=software \
+    LIBGL_ALWAYS_SOFTWARE=1 \
+    QT_XCB_GL_INTEGRATION=none \
+    QSG_RENDER_LOOP=basic \
+    QT_QUICK_CONTROLS_STYLE=Material
+
+# --- qml_runner (개선판) 빌드 ---
+RUN mkdir -p /usr/local/src/qml_runner
+COPY docker/qml_runner/main.cpp       /usr/local/src/qml_runner/main.cpp
+COPY docker/qml_runner/CMakeLists.txt /usr/local/src/qml_runner/CMakeLists.txt
+RUN cmake -S /usr/local/src/qml_runner -B /tmp/qml_runner \
+ && cmake --build /tmp/qml_runner -j \
+ && install -Dm755 /tmp/qml_runner/qml_runner /usr/local/bin/qml_runner \
+ && rm -rf /tmp/qml_runner
+
+# QML import 기본 경로
+ENV QML2_IMPORT_PATH=/ws/install/qml_ros2_plugin/lib
+
+# 런타임 스크립트
+COPY docker/scripts/qml_env.sh   /usr/local/share/qml_ros2_plugin/qml_env.sh
+COPY docker/scripts/run-sub      /usr/local/bin/run-sub
+COPY docker/scripts/run-pub      /usr/local/bin/run-pub
+COPY docker/run-headless.sh      /usr/local/bin/run-headless.sh
+
+RUN chmod +x /usr/local/bin/run-sub /usr/local/bin/run-pub /usr/local/bin/run-headless.sh /usr/local/bin/qml_runner \
+ && ln -sf /usr/local/share/qml_ros2_plugin/qml_env.sh /usr/local/bin/qml_env.sh || true
+
+EXPOSE 6080
+RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc
+CMD ["/usr/local/bin/run-headless.sh"]
+

--- a/docker/qml_runner/CMakeLists.txt
+++ b/docker/qml_runner/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.12)
+project(qml_runner LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Qml Quick)
+
+add_executable(qml_runner main.cpp)
+target_link_libraries(qml_runner Qt5::Core Qt5::Gui Qt5::Qml Qt5::Quick)
+

--- a/docker/qml_runner/main.cpp
+++ b/docker/qml_runner/main.cpp
@@ -1,0 +1,63 @@
+#include <QGuiApplication>
+#include <QQuickView>
+#include <QQmlApplicationEngine>
+#include <QCommandLineParser>
+#include <QFileInfo>
+#include <QUrl>
+#include <QDebug>
+#include <QWindow>
+#include <QRegularExpression>
+
+static bool applyGeometry(QWindow* win, const QString& geom) {
+    QRegularExpression re("^(\\d+)x(\\d+)\\+(\\-?\\d+)\\+(\\-?\\d+)$");
+    auto m = re.match(geom);
+    if (!m.hasMatch()) return false;
+    win->resize(m.captured(1).toInt(), m.captured(2).toInt());
+    win->setPosition(m.captured(3).toInt(), m.captured(4).toInt());
+    return true;
+}
+
+int main(int argc, char *argv[]) {
+    QGuiApplication app(argc, argv);
+    QCommandLineParser parser;
+    parser.setApplicationDescription("qml_runner (supports non-Window & forces Window.show())");
+    parser.addHelpOption();
+    QCommandLineOption geometryOpt({"g","geometry"}, "Geometry WxH+X+Y.", "geom");
+    parser.addOption(geometryOpt);
+    parser.addPositionalArgument("file", "QML file");
+    parser.process(app);
+
+    const auto args = parser.positionalArguments();
+    if (args.isEmpty()) { qWarning() << "[qml_runner] No QML file specified."; return 1; }
+    const QString qmlPath = QFileInfo(args.first()).absoluteFilePath();
+    const QUrl url = QUrl::fromLocalFile(qmlPath);
+    const QString geom = parser.value(geometryOpt);
+
+    // 1) QQuickView (Item/Rectangle 루트)
+    QQuickView view;
+    view.setResizeMode(QQuickView::SizeRootObjectToView);
+    view.setSource(url);
+    if (view.errors().isEmpty()) {
+        view.show();
+        return app.exec();
+    }
+    for (const auto &e : view.errors()) qWarning() << "[qml_runner] view error:" << e.toString();
+
+    // 2) QQmlApplicationEngine (Window 루트) + 강제 show()
+    QQmlApplicationEngine engine;
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated, &app,
+                     [&url](QObject *obj, const QUrl &objUrl) {
+                         if (!obj && url == objUrl) QCoreApplication::exit(-1);
+                     }, Qt::QueuedConnection);
+    engine.load(url);
+    if (engine.rootObjects().isEmpty()) { qCritical() << "[qml_runner] No root objects after load."; return 1; }
+
+    for (QObject* obj : engine.rootObjects()) {
+        if (auto *win = qobject_cast<QWindow*>(obj)) {
+            if (!geom.isEmpty()) applyGeometry(win, geom);
+            if (!win->isVisible()) win->show();
+        }
+    }
+    return app.exec();
+}
+

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -1,19 +1,41 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-# X11 허용(로컬 Xorg 기준; 테스트 후 xhost -local:root로 되돌리세요)
-xhost +local:root 1>/dev/null 2>&1 || true
-
+# === Host paths ===
 HOST_SRC="${HOST_SRC:-$HOME/Documents/Aelleek/qml_ros2_plugin}"
+
+# === X11 / Auth (host side values) ===
+DISPLAY_VAL="${DISPLAY:-:0}"
+XAUTH_HOST="${XAUTHORITY:-$HOME/.Xauthority}"
+
+if [ ! -f "$XAUTH_HOST" ]; then
+  echo "[ERR] Xauthority not found: $XAUTH_HOST"
+  echo "      GUI 로그인 세션의 터미널에서 실행하고 있는지 확인하세요."
+  echo "      (원격 SSH면 X 포워딩/VNC 등 별도 설정 필요)"
+  exit 1
+fi
 
 docker run --rm -it \
   --net=host \
-  -e DISPLAY=$DISPLAY \
+  -e DISPLAY="${DISPLAY_VAL}" \
+  -e XAUTHORITY=/tmp/.Xauthority \
+  -e QT_QPA_PLATFORM=xcb \
+  -e QT_SELECT=qt5 \
+  -v "$XAUTH_HOST":/tmp/.Xauthority:ro \
   -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
   -v "$HOST_SRC":/ws/src/qml_ros2_plugin:rw \
   --workdir /ws \
   qmlros2:humble \
-  bash -lc "source /opt/ros/humble/setup.bash && \
-            colcon build --symlink-install && \
-            source install/setup.bash && \
-            bash"
+  bash -lc 'set -e
+    # ROS env
+    source /opt/ros/humble/setup.bash
+
+    # 빌드(루트 권한으로 /ws 에 산출물 생성)
+    colcon build --symlink-install
+
+    # 오버레이 활성화
+    source install/setup.bash
+
+    # 인터랙티브 셸 유지
+    bash'
+

--- a/docker/run-headless.sh
+++ b/docker/run-headless.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${IMAGE:=qmlros2:humble-qt}"
+: "${NAME:=qmlros2_hmi}"
+: "${HOST_PORT:=6901}"
+: "${CONTAINER_PORT:=6080}"
+: "${SRC_DIR:=$PWD}"
+: "${SHM_SIZE:=2g}"
+
+if command -v lsof >/dev/null 2>&1; then
+  lsof -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1 && echo "[WARN] Host port ${HOST_PORT} already in LISTEN state."
+fi
+
+docker ps -a --format '{{.Names}}' | grep -q "^${NAME}$" && docker rm -f "${NAME}" >/dev/null 2>&1 || true
+
+docker run --name "${NAME}" --rm -it \
+  -p "${HOST_PORT}:${CONTAINER_PORT}" \
+  --shm-size="${SHM_SIZE}" \
+  -v "${SRC_DIR}":/ws/src/qml_ros2_plugin:rw \
+  "${IMAGE}" \
+  bash -lc '
+set -Eeuo pipefail
+
+: "${DISPLAY:=:0}"
+: "${GEOM:=1280x800x24}"
+: "${CONTAINER_PORT:=6080}"
+: "${QT_QPA_PLATFORM:=xcb}"
+: "${QT_QUICK_BACKEND:=software}"
+: "${LIBGL_ALWAYS_SOFTWARE:=1}"
+: "${QT_XCB_GL_INTEGRATION:=none}"
+: "${QSG_RENDER_LOOP:=basic}"
+export DISPLAY QT_QPA_PLATFORM QT_QUICK_BACKEND LIBGL_ALWAYS_SOFTWARE QT_XCB_GL_INTEGRATION QSG_RENDER_LOOP
+
+# 로그 초기화
+: > /tmp/xvfb.log; : > /tmp/fluxbox.log; : > /tmp/x11vnc.log; : > /tmp/novnc.log
+
+# ROS env
+set +u; [ -f /opt/ros/humble/setup.bash ] && source /opt/ros/humble/setup.bash; set -u
+
+# 1) Xvfb/fluxbox/x11vnc/noVNC
+Xvfb "${DISPLAY}" -screen 0 "${GEOM}" >/tmp/xvfb.log 2>&1 & sleep 0.2
+fluxbox >/tmp/fluxbox.log 2>&1 & sleep 0.2
+x11vnc -display "${DISPLAY}" -forever -shared -nopw -rfbport 5900 -localhost >/tmp/x11vnc.log 2>&1 & sleep 0.2
+if [ -x /usr/share/novnc/utils/novnc_proxy ]; then
+  /usr/share/novnc/utils/novnc_proxy --vnc localhost:5900 --listen "${CONTAINER_PORT}" >/tmp/novnc.log 2>&1 &
+else
+  websockify --web=/usr/share/novnc "${CONTAINER_PORT}" localhost:5900 >/tmp/novnc.log 2>&1 &
+fi
+
+# 2) qml_ros2_plugin 자동 빌드(없을 때만)
+PLUGIN_SO="/ws/install/qml_ros2_plugin/lib/Ros2/libqml_ros2_plugin.so"
+if [ ! -f "$PLUGIN_SO" ]; then
+  echo "[INFO] First run: building qml_ros2_plugin..."
+  cd /ws && rm -rf build install log
+  # QoS::BestAvailable → Humble 호환 치환(있을 때만)
+  if grep -RIl --exclude-dir=install --exclude-dir=build --exclude-dir=.git "BestAvailable" /ws/src/qml_ros2_plugin >/dev/null 2>&1; then
+    sed -i.bak -E \
+      "s/rclcpp::QoS::BestAvailable\\s*\\(\\s*\\)/rclcpp::QoS(rclcpp::KeepLast(10)).reliability(rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_RELIABLE).durability(rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_VOLATILE)/g" \
+      /ws/src/qml_ros2_plugin/**/*.cpp /ws/src/qml_ros2_plugin/*.cpp 2>/dev/null || true
+  fi
+  colcon build --packages-select qml_ros2_plugin --symlink-install --event-handlers console_direct+
+  set +u; source /ws/install/setup.bash; set -u
+  export QML2_IMPORT_PATH=/ws/install/qml_ros2_plugin/lib
+  ln -snf /ws/install/qml_ros2_plugin/lib/Ros2 /ws/install/qml_ros2_plugin/lib/Ros || true
+  [ -f "$PLUGIN_SO" ] && echo "[OK] Built: $PLUGIN_SO" || { echo "[ERR] Plugin .so missing"; exit 2; }
+else
+  set +u; source /ws/install/setup.bash; set -u
+  export QML2_IMPORT_PATH=/ws/install/qml_ros2_plugin/lib
+  ln -snf /ws/install/qml_ros2_plugin/lib/Ros2 /ws/install/qml_ros2_plugin/lib/Ros || true
+fi
+
+echo "[READY] http://localhost:${CONTAINER_PORT}/vnc.html?autoconnect=1&resize=scale"
+tail -f /tmp/fluxbox.log /tmp/x11vnc.log /tmp/novnc.log
+'
+

--- a/docker/scripts/build-plugin
+++ b/docker/scripts/build-plugin
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# build-plugin
+# - qml_ros2_plugin 빌드(클린) + Humble QoS 패치 + QML 모듈 링크
+# - 컨테이너 내부에서 실행됨 (이미지에 포함)
+# - set -u 환경에서도 안전하도록 setup.bash는 set +u로 감싸서 source
+# ------------------------------------------------------------
+set -Eeuo pipefail
+
+# nounset로 터지는 변수들 기본값 미리 지정
+export AMENT_TRACE_SETUP_FILES=${AMENT_TRACE_SETUP_FILES:-0}
+export AMENT_PYTHON_EXECUTABLE=${AMENT_PYTHON_EXECUTABLE:-/usr/bin/python3}
+
+# ROS 환경 로드 (nounset 우회)
+set +u; source /opt/ros/humble/setup.bash; set -u
+
+# Humble 호환 QoS 패치 (BestAvailable → KeepLast(10)+Reliable+Volatile)
+sed -i.bak -E 's/BestAvailable\s*\(\s*\)/rclcpp::QoS(rclcpp::KeepLast(10)).reliability(rclcpp::ReliabilityPolicy::Reliable).durability(rclcpp::DurabilityPolicy::Volatile)/g' \
+  /ws/src/qml_ros2_plugin/src/*.cpp /ws/src/qml_ros2_plugin/src/*/*.cpp 2>/dev/null || true
+
+# 클린 빌드
+cd /ws && rm -rf build install log
+colcon build --packages-select qml_ros2_plugin --event-handlers console_direct+
+
+# 설치된 환경 로드 + 링크 (nounset 우회)
+set +u; source /ws/install/setup.bash; set -u
+ln -snf /ws/install/qml_ros2_plugin/lib/Ros2 /ws/install/qml_ros2_plugin/lib/Ros
+
+echo "[OK] qml_ros2_plugin built and linked."
+

--- a/docker/scripts/patch_qos.sh
+++ b/docker/scripts/patch_qos.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Replace QoS::BestAvailable with explicit settings for Humble
+# Run from repo root before colcon build or add to Docker build step.
+
+FILES=$(grep -RIl --exclude-dir=install --exclude-dir=build --exclude-dir=.git "BestAvailable" . || true)
+if [ -z "${FILES}" ]; then
+  echo "[INFO] No BestAvailable symbols found."
+  exit 0
+fi
+
+echo "[INFO] Patching BestAvailable in:"
+echo "${FILES}"
+
+# Patch in-place
+for f in ${FILES}; do
+  sed -i \
+    -e 's/rclcpp::QoS::BestAvailable()/rclcpp::QoS(rclcpp::KeepLast(10)).reliability(rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_RELIABLE).durability(rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_VOLATILE)/g' \
+    "$f"
+done
+
+echo "[OK] Patched. Rebuild the workspace."
+

--- a/docker/scripts/qml_env.sh
+++ b/docker/scripts/qml_env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# ROS & headless Qt env (set -u 안전)
+set +u
+[ -f /opt/ros/humble/setup.bash ] && source /opt/ros/humble/setup.bash
+[ -f /ws/install/setup.bash ] && source /ws/install/setup.bash
+set -u
+
+: "${AMENT_TRACE_SETUP_FILES:=0}"
+: "${AMENT_PYTHON_EXECUTABLE:=/usr/bin/python3}"
+: "${COLCON_TRACE:=0}"
+
+: "${DISPLAY:=:0}"
+: "${QT_QPA_PLATFORM:=xcb}"
+: "${QT_QUICK_BACKEND:=software}"
+: "${LIBGL_ALWAYS_SOFTWARE:=1}"
+: "${QT_XCB_GL_INTEGRATION:=none}"
+: "${QSG_RENDER_LOOP:=basic}"
+
+export AMENT_TRACE_SETUP_FILES AMENT_PYTHON_EXECUTABLE COLCON_TRACE
+export DISPLAY QT_QPA_PLATFORM QT_QUICK_BACKEND LIBGL_ALWAYS_SOFTWARE QT_XCB_GL_INTEGRATION QSG_RENDER_LOOP
+
+# QML import path & Ros 링크
+if [ -d /ws/install/qml_ros2_plugin/lib ]; then
+  export QML2_IMPORT_PATH=/ws/install/qml_ros2_plugin/lib
+fi
+if [ -n "${QML2_IMPORT_PATH:-}" ] && [ -d "${QML2_IMPORT_PATH}/Ros2" ] && [ ! -e "${QML2_IMPORT_PATH}/Ros" ]; then
+  ln -s "${QML2_IMPORT_PATH}/Ros2" "${QML2_IMPORT_PATH}/Ros" 2>/dev/null || true
+fi
+
+: "${QT_DEBUG_PLUGINS:=0}"
+: "${QML_IMPORT_TRACE:=0}"
+: "${QSG_INFO:=0}"
+export QT_DEBUG_PLUGINS QML_IMPORT_TRACE QSG_INFO
+

--- a/docker/scripts/run-pub
+++ b/docker/scripts/run-pub
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if   [ -f /usr/local/share/qml_ros2_plugin/qml_env.sh ]; then source /usr/local/share/qml_ros2_plugin/qml_env.sh
+elif [ -f /usr/local/bin/qml_env.sh ]; then source /usr/local/bin/qml_env.sh
+else echo "[ERR] qml_env.sh not found"; exit 1; fi
+
+LAUNCHER="qml_runner"
+PREFERRED="/ws/src/qml_ros2_plugin/examples/publisher.qml"
+FALLBACK="/ws/install/qml_ros2_plugin/share/qml_ros2_plugin/examples/publisher.qml"
+
+if   [ -f "$PREFERRED" ]; then QMLFILE="$PREFERRED"
+elif [ -f "$FALLBACK"  ]; then QMLFILE="$FALLBACK"
+else echo "[ERR] publisher.qml not found: $PREFERRED | $FALLBACK"; exit 1; fi
+
+mkdir -p /tmp
+exec $LAUNCHER -geometry "${GEOM:-900x640+980+40}" "$QMLFILE" > /tmp/pub.log 2>&1
+

--- a/docker/scripts/run-sub
+++ b/docker/scripts/run-sub
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if   [ -f /usr/local/share/qml_ros2_plugin/qml_env.sh ]; then source /usr/local/share/qml_ros2_plugin/qml_env.sh
+elif [ -f /usr/local/bin/qml_env.sh ]; then source /usr/local/bin/qml_env.sh
+else echo "[ERR] qml_env.sh not found"; exit 1; fi
+
+LAUNCHER="qml_runner"
+PREFERRED="/ws/src/qml_ros2_plugin/examples/subscription.qml"
+FALLBACK="/ws/install/qml_ros2_plugin/share/qml_ros2_plugin/examples/subscription.qml"
+
+if   [ -f "$PREFERRED" ]; then QMLFILE="$PREFERRED"
+elif [ -f "$FALLBACK"  ]; then QMLFILE="$FALLBACK"
+else echo "[ERR] subscription.qml not found: $PREFERRED | $FALLBACK"; exit 1; fi
+
+mkdir -p /tmp
+exec $LAUNCHER -geometry "${GEOM:-900x640+40+40}" "$QMLFILE" > /tmp/sub.log 2>&1
+

--- a/src/qos.cpp
+++ b/src/qos.cpp
@@ -62,7 +62,6 @@ std::string to_string( const rclcpp::ReliabilityPolicy &reliability )
     return "Reliable";
   case rclcpp::ReliabilityPolicy::SystemDefault:
     return "SystemDefault";
-  case rclcpp::ReliabilityPolicy::BestAvailable:
     return "BestAvailable";
   case rclcpp::ReliabilityPolicy::Unknown:
     return "Unknown";
@@ -81,7 +80,6 @@ std::string to_string( const rclcpp::DurabilityPolicy &durability )
     return "SystemDefault";
   case rclcpp::DurabilityPolicy::Unknown:
     return "Unknown";
-  case rclcpp::DurabilityPolicy::BestAvailable:
     return "BestAvailable";
   }
   return "Invalid";

--- a/src/ros2.cpp
+++ b/src/ros2.cpp
@@ -327,7 +327,7 @@ QoSWrapper Ros2QmlSingletonWrapper::QoS() { return {}; }
 
 QoSWrapper Ros2QmlSingletonWrapper::BestAvailableQoS()
 {
-  return QoSWrapper( rclcpp::BestAvailableQoS() );
+  return QoSWrapper( rclcpp::QoS(rclcpp::KeepLast(10)) );
 }
 QoSWrapper Ros2QmlSingletonWrapper::ClockQoS() { return QoSWrapper( rclcpp::ClockQoS() ); }
 


### PR DESCRIPTION
qmlscene 의존 제거, qml_runner가 Window/Item 루트 모두 표시 (강제 show).

run-headless.sh: Xvfb/fluxbox/x11vnc/noVNC 기동 + 최초 자동 빌드 + QML2_IMPORT_PATH & Ros↔Ros2 링크 보장.

run-sub/run-pub: 정확 QML 경로, env 자동 로드.

set -u 안전 기본값, CONTAINER_PORT 포함.

신규 Dockerfile Dockerfile.humble-qt.